### PR TITLE
PNG output

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+scene="<path to the scene file>"
+output="./output.ppm"
+width=512
+height=512
+max-color=255
+reflection-limit=10
+progress-bar=1 # True

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 scene="<path to the scene file>"
-output="./output.ppm"
+output="./output.png"
+output-format="png"
 width=512
 height=512
 max-color=255

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 todo
 .env
 *.ppm
+*.png

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__
 
 .misc
+todo
 .env
 *.ppm

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN pip install pylint
 RUN pip install numpy
 RUN pip install python-dotenv
 RUN pip install tqdm
+RUN pip install Pillow
 
 WORKDIR /ray-tracer
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ A simple [ray tracer](https://en.wikipedia.org/wiki/Ray_tracing_(graphics)) writ
 
 Without a custom license, this code is the direct intellectual property of the original developer. It may not be used, modified, or shared without explicit permission. Please see [GitHub's guide on licensing](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository).
 
+## Versioning
+
+This project abides by [Semantic Versioning](https://semver.org/).
+
+To see a changelog for each update, check the description of [releases on GitHub](https://github.com/JstnMcBrd/ray-tracer/releases).
+
 ## Running
 
 You can run the ray tracer with the following command:

--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ You can run the ray tracer with the following command:
 python ./src/main.py
 ```
 
-The script has many arguments. Use the `--help` command to see a full list.
-
-Most arguments have default values, but not all. You will likely want to override these values by providing them yourself. Additionally, you must provide all arguments that lack a default value.
+The script has many arguments. Use the `--help` command to see a full list. Some have a default values, but you must provide the rest yourself.
 
 Passing all the arguments through the command line can get tedious, so this project has support for `dotenv`.
 
@@ -41,7 +39,7 @@ reflection-limit=10
 progress-bar=1 # True
 ```
 
-You may still pass the arguments through the command prompt, and your `.env` values will be ignored.
+You may still pass arguments through the command prompt, and your `.env` values will be ignored.
 
 ## Output
 
@@ -189,8 +187,6 @@ class Triangle extends Polygon {
 
 ## Future Plans
 
-- Loading bar for writing to file
-- More command line output to announce stages
 - More shapes
 	- Rectangles
 	- Rectangular Prisms

--- a/README.md
+++ b/README.md
@@ -26,18 +26,7 @@ The script has many arguments. Use the `--help` command to see a full list. Some
 
 Passing all the arguments through the command line can get tedious, so this project has support for `dotenv`.
 
-Create a new file called `.env` in the root folder and add any arguments you reuse often. These will act as new "default" values.
-
-Here is an sample `.env` with the default values of all required arguments.
-```bash
-scene="<path to the scene file>"
-output="./output.ppm"
-width=512
-height=512
-max-color=255
-reflection-limit=10
-progress-bar=1 # True
-```
+Create a new file called `.env` in the root folder and add any arguments you reuse often. These will act as new "default" values. You can find a sample `.env` with all the default values in [`.env.example`](./.env.example).
 
 You may still pass arguments through the command prompt, and your `.env` values will be ignored.
 

--- a/README.md
+++ b/README.md
@@ -116,14 +116,14 @@ class Circle extends Object {
 	/** Defines this object as a Circle. */
 	type: string = "circle";
 
-	/** The central location of the Circle. */
-	center: Position;
+	/** The center of the Circle. */
+	position: Position;
+
+	/** The direction the circle faces. */
+	normal: Direction = [0, 0, 1];
 
 	/** The radius of the Circle. Must be greater than 0. */
 	radius: number;
-
-	/** The direction the circle faces. */
-	normal: Direction;
 };
 
 /** The specific values necessary for Planes. */
@@ -131,11 +131,11 @@ class Plane extends Object {
 	/** Defines this object as a Plane. */
 	type: string = "plane";
 
+	/** Any position on the plane. */
+	position: Position = [0, 0, 0];
+
 	/** The direction the plane faces. */
 	normal: Direction;
-
-	/** Any position on the plane. */
-	point: Position = [0, 0, 0];
 };
 
 /** The specific values necessary for Polygons. */
@@ -152,14 +152,15 @@ class Sphere extends Object {
 	/** Defines this object as a Sphere. */
 	type: string = "sphere";
 
-	/** The central location of the Sphere. */
-	center: Position;
+	/** The center of the Sphere. */
+	position: Position;
 
 	/** The radius of the Sphere. Must be greater than 0. */
 	radius: number;
 };
 
-/** The specific values necessary for Triangles.
+/**
+ * The specific values necessary for Triangles.
  * The algorithm for Triangle intersections is slightly faster than Polygons,
  * so 3-sided Polygons will be automatically converted to Triangles.
 */

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You may still pass arguments through the command prompt, and your `.env` values 
 
 ## Output
 
-For now, this raytracer only formats output as `.ppm` files. [PPM](https://en.wikipedia.org/wiki/Netpbm) images can be difficult to open and view. Support for more commonly-used image encodings is a future goal.
+This raytracer can output images as `.png` files or `.ppm` files. Transparency is not supported, but is a future goal.
 
 ## Scenes
 

--- a/README.md
+++ b/README.md
@@ -173,25 +173,3 @@ class Triangle extends Polygon {
 // More types of objects can be added later.
 // In the meantime, most kinds of objects can be modeled with Polygons.
 ```
-
-## Future Plans
-
-- More shapes
-	- Rectangles
-	- Rectangular Prisms
-	- Cylinders
-	- Parameterized Surfaces
-- Refraction
-- Output images as PNGs
-- Transparency
-- More light types
-	- Point
-	- Area
-- Multiple light sources
-- Anti-aliasing
-- Distributed ray tracing
-- Mapping
-	- Texture
-	- Normal
-	- Reflection
-	- Transparency

--- a/scenes/program-5-scene-1.json
+++ b/scenes/program-5-scene-1.json
@@ -11,7 +11,7 @@
 		{
 			"name": "purple sphere",
 			"type": "sphere",
-			"center": [0.0, 0.0, 0.0],
+			"position": [0.0, 0.0, 0.0],
 			"radius": 0.4,
 			"ambient_coefficient": 0.1,
 			"diffuse_coefficient": 0.7,

--- a/scenes/program-5-scene-2.json
+++ b/scenes/program-5-scene-2.json
@@ -11,7 +11,7 @@
 		{
 			"name": "white sphere",
 			"type": "sphere",
-			"center": [0.45, 0.0, -0.15],
+			"position": [0.45, 0.0, -0.15],
 	  		"radius": 0.15,
 	  		"ambient_coefficient": 0.3,
 	  		"diffuse_coefficient": 0.8,
@@ -24,7 +24,7 @@
 		{
 			"name": "red sphere",
 			"type": "sphere",
-			"center": [0.0, 0.0, -0.1],
+			"position": [0.0, 0.0, -0.1],
 			"radius": 0.2,
 			"ambient_coefficient": 0.1,
 			"diffuse_coefficient": 0.6,
@@ -37,7 +37,7 @@
 		{
 			"name": "green sphere",
 			"type": "sphere",
-			"center": [-0.6, 0.0, 0.0],
+			"position": [-0.6, 0.0, 0.0],
 			"radius": 0.3,
 			"ambient_coefficient": 0.1,
 			"diffuse_coefficient": 0.7,
@@ -50,7 +50,7 @@
 		{
 			"name": "blue sphere",
 			"type": "sphere",
-			"center": [0.0, -10000.5, 0.0],
+			"position": [0.0, -10000.5, 0.0],
 			"radius": 10000.0,
 			"ambient_coefficient": 0.1,
 			"diffuse_coefficient": 0.9,

--- a/scenes/program-5-scene-3.json
+++ b/scenes/program-5-scene-3.json
@@ -11,7 +11,7 @@
 		{
 			"name": "red",
 			"type": "sphere",
-			"center": [0.5, 0.0, 0.0],
+			"position": [0.5, 0.0, 0.0],
 			"radius": 0.25,
 			"ambient_coefficient": 0.1,
 			"diffuse_coefficient": 0.7,
@@ -24,7 +24,7 @@
 		{
 			"name": "pink",
 			"type": "sphere",
-			"center": [0.35, 0.35, 0.0],
+			"position": [0.35, 0.35, 0.0],
 			"radius": 0.25,
 			"ambient_coefficient": 0.1,
 			"diffuse_coefficient": 0.7,
@@ -37,7 +37,7 @@
 		{
 			"name": "purple",
 			"type": "sphere",
-			"center": [0.0, 0.5, 0.0],
+			"position": [0.0, 0.5, 0.0],
 			"radius": 0.25,
 			"ambient_coefficient": 0.1,
 			"diffuse_coefficient": 0.7,
@@ -50,7 +50,7 @@
 		{
 			"name": "blue",
 			"type": "sphere",
-			"center": [-0.35, 0.35, 0.0],
+			"position": [-0.35, 0.35, 0.0],
 			"radius": 0.25,
 			"ambient_coefficient": 0.1,
 			"diffuse_coefficient": 0.7,
@@ -63,7 +63,7 @@
 		{
 			"name": "aquamarine",
 			"type": "sphere",
-			"center": [-0.5, 0.0, 0.0],
+			"position": [-0.5, 0.0, 0.0],
 			"radius": 0.25,
 			"ambient_coefficient": 0.1,
 			"diffuse_coefficient": 0.7,
@@ -76,7 +76,7 @@
 		{
 			"name": "green",
 			"type": "sphere",
-			"center": [-0.35, -0.35, 0.0],
+			"position": [-0.35, -0.35, 0.0],
 			"radius": 0.25,
 			"ambient_coefficient": 0.1,
 			"diffuse_coefficient": 0.7,
@@ -89,7 +89,7 @@
 		{
 			"name": "lime",
 			"type": "sphere",
-			"center": [0.0, -0.5, 0.0],
+			"position": [0.0, -0.5, 0.0],
 			"radius": 0.25,
 			"ambient_coefficient": 0.1,
 			"diffuse_coefficient": 0.7,
@@ -102,7 +102,7 @@
 		{
 			"name": "yellow-orange",
 			"type": "sphere",
-			"center": [0.35, -0.35, 0.0],
+			"position": [0.35, -0.35, 0.0],
 			"radius": 0.25,
 			"ambient_coefficient": 0.1,
 			"diffuse_coefficient": 0.7,
@@ -115,7 +115,7 @@
 		{
 			"name": "middle sphere",
 			"type": "sphere",
-			"center": [0.0, 0.0, -0.1],
+			"position": [0.0, 0.0, -0.1],
 			"radius": 0.4,
 			"ambient_coefficient": 0.1,
 			"diffuse_coefficient": 0.7,

--- a/scenes/program-6-scene-1.json
+++ b/scenes/program-6-scene-1.json
@@ -11,7 +11,7 @@
 		{
 			"name": "reflective sphere",
 			"type": "sphere",
-			"center": [0.0, 0.3, -1.0],
+			"position": [0.0, 0.3, -1.0],
 			"radius": 0.25,
 			"ambient_coefficient": 0.1,
 			"diffuse_coefficient": 0.0,

--- a/scenes/program-6-scene-2.json
+++ b/scenes/program-6-scene-2.json
@@ -11,7 +11,7 @@
 		{
 			"name": "white sphere",
 			"type": "sphere",
-			"center": [0.5, 0.0, -0.15],
+			"position": [0.5, 0.0, -0.15],
 			"radius": 0.05,
 			"ambient_coefficient": 0.3,
 			"diffuse_coefficient": 0.8,
@@ -24,7 +24,7 @@
 		{
 			"name": "red sphere",
 			"type": "sphere",
-			"center": [0.3, 0.0, -0.1],
+			"position": [0.3, 0.0, -0.1],
 			"radius": 0.08,
 			"ambient_coefficient": 0.1,
 			"diffuse_coefficient": 0.8,
@@ -37,7 +37,7 @@
 		{
 			"name": "green sphere",
 			"type": "sphere",
-			"center": [-0.6, 0.0, 0.0],
+			"position": [-0.6, 0.0, 0.0],
 			"radius": 0.3,
 			"ambient_coefficient": 0.1,
 			"diffuse_coefficient": 0.7,
@@ -50,7 +50,7 @@
 		{
 			"name": "reflective sphere",
 			"type": "sphere",
-			"center": [0.1, -0.55, 0.25],
+			"position": [0.1, -0.55, 0.25],
 			"radius": 0.3,
 			"ambient_coefficient": 0.1,
 			"diffuse_coefficient": 0.0,

--- a/scenes/program-6-scene-3.json
+++ b/scenes/program-6-scene-3.json
@@ -11,8 +11,8 @@
 		{
 			"name": "front mirror",
 			"type": "plane",
+			"position": [0, 0, -0.25],
 			"normal": [0, 0, 1],
-			"point": [0, 0, -0.25],
 			"ambient_coefficient": 0.0,
 			"diffuse_coefficient": 0.0,
 			"specular_coefficient": 1.0,
@@ -24,8 +24,8 @@
 		{
 			"name": "back mirror",
 			"type": "plane",
+			"position": [0, 0, 1],
 			"normal": [0, 0, -1],
-			"point": [0, 0, 1],
 			"ambient_coefficient": 0.0,
 			"diffuse_coefficient": 0.0,
 			"specular_coefficient": 1.0,
@@ -37,8 +37,8 @@
 		{
 			"name": "left mirror",
 			"type": "plane",
+			"position": [-0.75, 0, 0],
 			"normal": [1, 0, 0],
-			"point": [-0.75, 0, 0],
 			"ambient_coefficient": 0.0,
 			"diffuse_coefficient": 0.0,
 			"specular_coefficient": 1.0,
@@ -50,8 +50,8 @@
 		{
 			"name": "right mirror",
 			"type": "plane",
+			"position": [0.75, 0, 0],
 			"normal": [-1, 0, 0],
-			"point": [0.75, 0, 0],
 			"ambient_coefficient": 0.0,
 			"diffuse_coefficient": 0.0,
 			"specular_coefficient": 1.0,
@@ -63,8 +63,8 @@
 		{
 			"name": "bottom mirror",
 			"type": "plane",
+			"position": [0, -0.25, 0],
 			"normal": [0, 1, 0],
-			"point": [0, -0.25, 0],
 			"ambient_coefficient": 0.0,
 			"diffuse_coefficient": 0.1,
 			"specular_coefficient": 1.0,
@@ -76,7 +76,7 @@
 		{
 			"name": "mirror sphere 1",
 			"type": "sphere",
-			"center": [-0.5, 0.0, 0.0],
+			"position": [-0.5, 0.0, 0.0],
 			"radius": 0.25,
 			"ambient_coefficient": 0.0,
 			"diffuse_coefficient": 0.0,
@@ -89,7 +89,7 @@
 		{
 			"name": "mirror sphere 2",
 			"type": "sphere",
-			"center": [0.5, 0.0, 0.0],
+			"position": [0.5, 0.0, 0.0],
 			"radius": 0.25,
 			"ambient_coefficient": 0.0,
 			"diffuse_coefficient": 0.0,
@@ -102,7 +102,7 @@
 		{
 			"name": "purple sphere",
 			"type": "sphere",
-			"center": [0.0, 0.0, 0.0],
+			"position": [0.0, 0.0, 0.0],
 			"radius": 0.25,
 			"ambient_coefficient": 0.1,
 			"diffuse_coefficient": 0.7,

--- a/src/main.py
+++ b/src/main.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
 	# Retrieve arguments overrides from command line
 	#	(A command line argument is only required if the environment variable is missing.)
 	arg = ArgumentParser("Ray Tracer")
-	arg.add_argument("-s", "--scene", "-i", "--input", type=str, help="Path to the scene file",
+	arg.add_argument("-s", "--scene", type=str, help="Path to the scene file",
 		default=env_scene, required=env_scene is None)
 	arg.add_argument("-o", "--output", type=str, help="Path to the output file",
 		default=env_output, required=env_output is None)

--- a/src/main.py
+++ b/src/main.py
@@ -14,13 +14,14 @@ from dotenv import load_dotenv
 
 from ray_tracer import ray_trace
 from scene_importer import import_scene
-from writers import write_to_ppm
+from writers import write_to_ppm, write_to_png
 
 
 if __name__ == "__main__":
 
 	# Default arguments
-	DEFAULT_OUTPUT = "./output.ppm"
+	DEFAULT_OUTPUT = "./output.png"
+	DEFAULT_OUTPUT_FORMAT = "png"
 	DEFAULT_WIDTH = 512
 	DEFAULT_HEIGHT = 512
 	DEFAULT_MAX_COLOR = 255
@@ -33,6 +34,7 @@ if __name__ == "__main__":
 	load_dotenv()
 	env_scene = getenv("scene")
 	env_output = getenv("output", default=DEFAULT_OUTPUT)
+	env_output_format = getenv("output-format", default=DEFAULT_OUTPUT_FORMAT)
 	env_width = getenv("width", default=str(DEFAULT_WIDTH))
 	env_height = getenv("height", default=str(DEFAULT_HEIGHT))
 	env_max_color = getenv("max-color", default=str(DEFAULT_MAX_COLOR))
@@ -46,6 +48,8 @@ if __name__ == "__main__":
 		default=env_scene, required=env_scene is None)
 	arg.add_argument("-o", "--output", type=str, help="Path to the output file",
 		default=env_output, required=env_output is None)
+	arg.add_argument("-f", "--output-format", type=str, choices=["png", "ppm"], help="Format of the output image",
+		default=env_output_format, required=env_output_format is None)
 	arg.add_argument("-x", "--width", type=int, help="Width of the output image",
 		default=env_width, required=env_width is None)
 	arg.add_argument("-y", "--height", type=int, help="Height of the output image",
@@ -61,6 +65,7 @@ if __name__ == "__main__":
 	parsed = arg.parse_args()
 	scene_file_path = parsed.scene
 	output_file_path = parsed.output
+	output_format = parsed.output_format
 	width = parsed.width
 	height = parsed.height
 	max_color = parsed.max_color
@@ -89,7 +94,10 @@ if __name__ == "__main__":
 	# Write to file
 	print("> Exporting...")
 	start_time = datetime.now()
-	write_to_ppm(screen, output_file_path, max_color, progress_bar)
+	if output_format == "ppm":
+		write_to_ppm(screen, output_file_path, max_color, progress_bar)
+	elif output_format == "png":
+		write_to_png(screen, output_file_path, max_color)
 	time_elapsed = datetime.now() - start_time
 	print(f"Time elapsed: {time_elapsed}")
 	print("> Done")

--- a/src/objects.py
+++ b/src/objects.py
@@ -207,15 +207,6 @@ class Sphere(Object):
 		return RayCollision(self, ray, ray.origin + ray.direction*t)
 
 
-def triangle_area(vertex_1: np.ndarray, vertex_2: np.ndarray, vertex_3: np.ndarray):
-	""" Given the three vertices, returns the area of the enclosed triangle. """
-
-	area = (vertex_1[0] * (vertex_2[1] - vertex_3[1]) \
-	     + vertex_2[0] * (vertex_3[1] - vertex_1[1]) \
-			+ vertex_3[0] * (vertex_1[1] - vertex_2[1])) / 2.0
-	return abs(area)
-
-
 class Triangle(Polygon):
 	"""
 	The specific values necessary for Triangles. 
@@ -228,9 +219,7 @@ class Triangle(Polygon):
 
 		assert len(vertices) == 3, "Triangle must have 3 vertices"
 
-		self._flattened_area = triangle_area(self._flattened_vertices[0], 
-				       self._flattened_vertices[1], 
-					   self._flattened_vertices[2])
+		self._flattened_area = Triangle.area(self._flattened_vertices)
 
 	def ray_intersection(self, ray: Ray) -> RayCollision or None:
 		# See if ray intersects with plane
@@ -243,15 +232,26 @@ class Triangle(Polygon):
 		flattened_intersection = np.delete(intersection, self._plane_dominant_coord)
 
 		# Calculate areas
-		area_1 = triangle_area(self._flattened_vertices[0], self._flattened_vertices[1],
-			 flattened_intersection)
-		area_2 = triangle_area(self._flattened_vertices[0], self._flattened_vertices[2],
-			 flattened_intersection)
-		area_3 = triangle_area(self._flattened_vertices[1], self._flattened_vertices[2],
-			 flattened_intersection)
+		area_1 = Triangle.area([self._flattened_vertices[0], self._flattened_vertices[1],
+			 flattened_intersection])
+		area_2 = Triangle.area([self._flattened_vertices[0], self._flattened_vertices[2],
+			 flattened_intersection])
+		area_3 = Triangle.area([self._flattened_vertices[1], self._flattened_vertices[2],
+			 flattened_intersection])
 
 		# If point is inside triangle, then the area of all sub-triangles will add up to the total area
 		if abs(area_1 + area_2 + area_3 - self._flattened_area) > 0.01:
 			return None
 
 		return RayCollision(self, ray, intersection)
+	
+	@staticmethod
+	def area(vertices: list):
+		""" Given the three vertices, returns the area of the enclosed triangle. """
+
+		assert len(vertices) == 3, "Must have 3 vertices to be a triangle"
+
+		area = (vertices[0][0] * (vertices[1][1] - vertices[2][1]) \
+			+ vertices[1][0] * (vertices[2][1] - vertices[0][1]) \
+				+ vertices[2][0] * (vertices[0][1] - vertices[1][1])) / 2.0
+		return abs(area)

--- a/src/objects.py
+++ b/src/objects.py
@@ -240,11 +240,11 @@ class Triangle(Polygon):
 			 flattened_intersection])
 
 		# If point is inside triangle, then the area of all sub-triangles will add up to the total area
-		if abs(area_1 + area_2 + area_3 - self._flattened_area) > 0.01:
+		if abs(area_1 + area_2 + area_3 - self._flattened_area) > 0.0001:
 			return None
 
 		return RayCollision(self, ray, intersection)
-	
+
 	@staticmethod
 	def area(vertices: list):
 		""" Given the three vertices, returns the area of the enclosed triangle. """

--- a/src/objects.py
+++ b/src/objects.py
@@ -39,14 +39,14 @@ class Object:
 class Circle(Object):
 	""" The specific values necessary for Circles. """
 
-	def __init__(self, center: np.ndarray, radius: float, normal: np.ndarray):
+	def __init__(self, position: np.ndarray, normal: np.ndarray, radius: float):
 		super().__init__()
 
-		self.center = center
+		self.position = position
 		self.radius = radius
 
 		normal = normalized(normal)
-		self._plane = Plane(normal, center)
+		self._plane = Plane(position, normal)
 
 	def normal(self, point: np.ndarray = None) -> np.ndarray:
 		return self._plane.normal(point)
@@ -59,7 +59,7 @@ class Circle(Object):
 
 		# Check if intersection is within circle radius
 		intersection = plane_collision.position
-		distance = magnitude(intersection - self.center)
+		distance = magnitude(intersection - self.position)
 
 		if distance > self.radius:
 			return None
@@ -70,12 +70,11 @@ class Circle(Object):
 class Plane(Object):
 	""" The specific values necessary for Planes. """
 
-	def __init__(self, normal: np.ndarray, point: np.ndarray):
+	def __init__(self, position: np.ndarray, normal: np.ndarray):
 		super().__init__()
 
 		self._normal = normalized(normal)
-		self._point = point
-		self._distance_from_origin = -1 * np.dot(normal, point)
+		self._distance_from_origin = -1 * np.dot(normal, position)
 
 	def normal(self, point: np.ndarray = None) -> np.ndarray:
 		return self._normal
@@ -112,7 +111,7 @@ class Polygon(Object):
 
 		_normal = normalized(np.cross(vector_1, vector_2))
 
-		self._plane = Plane(_normal, vertices[0])
+		self._plane = Plane(vertices[0], _normal)
 
 		# Project all the vertices onto a 2D plane (for future intersection calculations)
 		self._plane_dominant_coord = np.where(np.abs(_normal) == np.max(np.abs(_normal)))[0][0]
@@ -174,16 +173,16 @@ class Polygon(Object):
 class Sphere(Object):
 	""" The specific values necessary for Spheres. """
 
-	def __init__(self, center: np.ndarray, radius: float):
+	def __init__(self, position: np.ndarray, radius: float):
 		super().__init__()
-		self.center = center
+		self.position = position
 		self.radius = radius
 
 	def normal(self, point: np.ndarray) -> np.ndarray:
-		return normalized(point - self.center)
+		return normalized(point - self.position)
 
 	def ray_intersection(self, ray: Ray) -> RayCollision|None:
-		dist = self.center - ray.origin
+		dist = self.position - ray.origin
 		dist_sqr = np.dot(dist, dist)
 		dist_mag = np.sqrt(dist_sqr)
 

--- a/src/scene_importer.py
+++ b/src/scene_importer.py
@@ -142,25 +142,25 @@ def _load_object(json_value, error_prefix="Object") -> Object:
 def _load_circle(json_value, error_prefix="Circle") -> Circle:
 	""" Imports Circle-specific values from a dictionary. """
 
-	center = _validate_position_vector(json_value.get("center"), default=[0,0,0],
-				     error_prefix=f"{error_prefix}.center")
-	radius = _validate_number(json_value.get("radius"), _min=0,
-			    error_prefix=f"{error_prefix}.radius")
+	position = _validate_position_vector(json_value.get("position"),
+				     error_prefix=f"{error_prefix}.position")
 	normal = _validate_direction_vector(json_value.get("normal"), default=[0,0,1],
 				      error_prefix=f"{error_prefix}.normal")
+	radius = _validate_number(json_value.get("radius"), _min=0,
+			    error_prefix=f"{error_prefix}.radius")
 
-	return Circle(center, radius, normal)
+	return Circle(position, normal, radius)
 
 
 def _load_plane(json_value, error_prefix="Plane") -> Plane:
 	""" Imports Plane-specific values from a dictionary. """
 
+	position = _validate_position_vector(json_value.get("position"), default=[0,0,0],
+				    error_prefix=f"{error_prefix}.position")
 	normal = _validate_direction_vector(json_value.get("normal"),
 				      error_prefix=f"{error_prefix}.normal")
-	point = _validate_position_vector(json_value.get("point"), default=[0,0,0],
-				    error_prefix=f"{error_prefix}.point")
 
-	return Plane(normal, point)
+	return Plane(position, normal)
 
 
 def _load_polygon(json_value, error_prefix="Polygon") -> Polygon:
@@ -185,12 +185,12 @@ def _load_polygon(json_value, error_prefix="Polygon") -> Polygon:
 def _load_sphere(json_value, error_prefix="Sphere") -> Sphere:
 	""" Imports Sphere-specific values from a dictionary. """
 
-	center = _validate_position_vector(json_value.get("center"),
-				     error_prefix=f"{error_prefix}.center")
+	position = _validate_position_vector(json_value.get("position"),
+				     error_prefix=f"{error_prefix}.position")
 	radius = _validate_number(json_value.get("radius"), _min=0,
 			    error_prefix=f"{error_prefix}.radius")
 
-	return Sphere(center, radius)
+	return Sphere(position, radius)
 
 
 def _load_triangle(json_value, error_prefix="Triangle") -> Triangle:

--- a/src/writers.py
+++ b/src/writers.py
@@ -5,6 +5,7 @@ Contains methods for writing the screen to image files.
 
 import numpy as np
 
+from PIL import Image
 from tqdm import tqdm
 
 
@@ -18,9 +19,23 @@ def write_to_ppm(screen: np.ndarray, output_file_path: str, max_color: float, pr
 		output_file.write(f"{max_color}\n")
 
 		# Pixels
-		pixels = [(x,y) for y in range(len(screen[0])) for x in range(len(screen))]
+		pixel_coords = [(x,y) for y in range(len(screen[0])) for x in range(len(screen))]
 		if progress_bar:
-			pixels = tqdm(pixels)
-		for x,y in pixels:
+			pixel_coords = tqdm(pixel_coords)
+		for x,y in pixel_coords:
 			pixel = screen[x,y]*max_color
 			output_file.write(f"{pixel[0]} {pixel[1]} {pixel[2]} ")
+
+
+def write_to_png(screen: np.ndarray, output_file_path: str, max_color: float):
+	""" Writes the screen to a file with [PNG](https://en.wikipedia.org/wiki/PNG) encoding. """
+
+	width = len(screen)
+	height = len(screen[0])
+
+	pixel_coords = [(x,y) for y in range(height) for x in range(width)]
+	pixels = [tuple((screen[x,y] * max_color).astype(int)) for x,y in pixel_coords]
+
+	image = Image.new('RGB', (width, height))
+	image.putdata(pixels)
+	image.save(output_file_path)


### PR DESCRIPTION
## Added
- Versioning section to `README`
- `.env.example` file
- Support for writing output to `PNG` files

## Changed
- Moved triangle area calculation into `Triangle` class
- Renamed `"center"` and `"point"` object attributes to `"position"`
- Reordered object attributes by position, rotation, size
- Output to go to .`png` files by default

## Fixed
- Triangle edges being cut off

## Removed
- --input argument alternative
- Future plans from `README`, using private `todo` list instead