### PR TITLE
Remove max-color argument

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,5 @@ output="./output.png"
 output-format="png"
 width=512
 height=512
-max-color=255
 reflection-limit=10
 progress-bar=1 # True

--- a/src/main.py
+++ b/src/main.py
@@ -24,7 +24,6 @@ if __name__ == "__main__":
 	DEFAULT_OUTPUT_FORMAT = "png"
 	DEFAULT_WIDTH = 512
 	DEFAULT_HEIGHT = 512
-	DEFAULT_MAX_COLOR = 255
 	DEFAULT_REFLECTION_LIMIT = 10
 	DEFAULT_PROGRESS_BAR = int(True)	# Must be an int because bools cannot be parsed from strings
 
@@ -37,7 +36,6 @@ if __name__ == "__main__":
 	env_output_format = getenv("output-format", default=DEFAULT_OUTPUT_FORMAT)
 	env_width = getenv("width", default=str(DEFAULT_WIDTH))
 	env_height = getenv("height", default=str(DEFAULT_HEIGHT))
-	env_max_color = getenv("max-color", default=str(DEFAULT_MAX_COLOR))
 	env_reflection_limit = getenv("reflection-limit", default=str(DEFAULT_REFLECTION_LIMIT))
 	env_progress_bar = getenv("progress-bar", default=str(DEFAULT_PROGRESS_BAR))
 
@@ -54,8 +52,6 @@ if __name__ == "__main__":
 		default=env_width, required=env_width is None)
 	arg.add_argument("-y", "--height", type=int, help="Height of the output image",
 		default=env_height, required=env_height is None)
-	arg.add_argument("-c", "--max-color", type=float, help="Max color of the ppm file",
-		default=env_max_color, required=env_max_color is None)
 	arg.add_argument("-r", "--reflection-limit", type=int, help="Max number of recursive reflections",
 		default=env_reflection_limit, required=env_reflection_limit is None)
 	arg.add_argument("-p", "--progress-bar", type=bool, help="Whether to show a progress bar",
@@ -95,9 +91,9 @@ if __name__ == "__main__":
 	print("> Exporting...")
 	start_time = datetime.now()
 	if output_format == "ppm":
-		write_to_ppm(screen, output_file_path, max_color, progress_bar)
+		write_to_ppm(screen, output_file_path, progress_bar)
 	elif output_format == "png":
-		write_to_png(screen, output_file_path, max_color)
+		write_to_png(screen, output_file_path, progress_bar)
 	time_elapsed = datetime.now() - start_time
 	print(f"Time elapsed: {time_elapsed}")
 	print("> Done")

--- a/src/main.py
+++ b/src/main.py
@@ -64,7 +64,6 @@ if __name__ == "__main__":
 	output_format = parsed.output_format
 	width = parsed.width
 	height = parsed.height
-	max_color = parsed.max_color
 	reflection_limit = parsed.reflection_limit
 	progress_bar = parsed.progress_bar
 

--- a/src/ray_tracer.py
+++ b/src/ray_tracer.py
@@ -112,7 +112,7 @@ def _is_in_shadow(point: np.ndarray, scene: Scene) -> bool:
 
 
 def _calculate_window_size(viewport_size: np.ndarray,
-				focal_length: np.ndarray,
+				focal_length: float,
 				field_of_view: float) -> np.ndarray:
 	""" Returns the window size, given the camera properties. """
 

--- a/src/writers.py
+++ b/src/writers.py
@@ -9,9 +9,10 @@ from PIL import Image
 from tqdm import tqdm
 
 
-def write_to_ppm(screen: np.ndarray, output_file_path: str, max_color: float, progress_bar: bool):
+def write_to_ppm(screen: np.ndarray, output_file_path: str, progress_bar: bool):
 	""" Writes the screen to a file with [PPM](https://en.wikipedia.org/wiki/Netpbm) encoding. """
 
+	max_color = 255
 	with open(output_file_path, mode="w", encoding="utf8") as output_file:
 		# Headers
 		output_file.write("P3\n")
@@ -27,7 +28,7 @@ def write_to_ppm(screen: np.ndarray, output_file_path: str, max_color: float, pr
 			output_file.write(f"{pixel[0]} {pixel[1]} {pixel[2]} ")
 
 
-def write_to_png(screen: np.ndarray, output_file_path: str, max_color: float):
+def write_to_png(screen: np.ndarray, output_file_path: str, progress_bar: bool):
 	""" Writes the screen to a file with [PNG](https://en.wikipedia.org/wiki/PNG) encoding. """
 
 	width = len(screen)

--- a/src/writers.py
+++ b/src/writers.py
@@ -41,6 +41,8 @@ def write_to_png(screen: np.ndarray, output_file_path: str, progress_bar: bool):
 
 	screen = (screen * 255).astype(int)
 	coords: Iterable = [(x,y) for y in range(height) for x in range(width)]
+	if progress_bar:
+		coords = tqdm(coords)
 
 	image = Image.new('RGB', (width, height))
 	for xy in coords:


### PR DESCRIPTION
### Added

- Progress bar to PNG writer

### Changed

- Improved and standardized writers

### Removed

- `max-color` command-line and environment arguments

### Fixed

- Bug where low `max-color` values would make PNG output contrast low after int truncation
- Incorrect type annotation in `_calculate_window_size`