### PR TITLE
Add type-checking with mypy

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,7 @@
 			"extensions": [
 				"ms-python.python",
 				"ms-python.pylint",
+				"ms-python.mypy-type-checker",
 				"github.vscode-github-actions",
 				"ngtystr.ppm-pgm-viewer-for-vscode"
 			]

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Lint
         run: pylint src
+
+      - name: Typecheck
+        run: mypy **/*.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
+.mypy_cache
 
 .misc
 todo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
 	"recommendations": [
 		"ms-python.python",
 		"ms-python.pylint",
+		"ms-python.mypy-type-checker",
 		"github.vscode-github-actions",
 		"ngtystr.ppm-pgm-viewer-for-vscode"
 	]

--- a/README.md
+++ b/README.md
@@ -185,8 +185,14 @@ class Triangle extends Polygon {
 
 ## Development
 
-To run Pylint, use
+To run the linter, use
 
 ```sh
 pylint src
+```
+
+To run the type-checker, use
+
+```sh
+mypy src/main.py
 ```

--- a/README.md
+++ b/README.md
@@ -194,5 +194,5 @@ pylint src
 To run the type-checker, use
 
 ```sh
-mypy src/main.py
+mypy **/*.py
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,8 @@ Pillow
 
 # Linting
 pylint
+
+# Typing
+mypy
+types-Pillow
+types-tqdm

--- a/src/lib/_multiprocessing.py
+++ b/src/lib/_multiprocessing.py
@@ -5,9 +5,10 @@ Add-ons to the builtin `multiprocessing` library.
 
 # This implementation is rather hacked and causes a lot of warnings and errors
 # that are inherent and cannot be resolved. So until I design something better,
-# I will disable linting for this file.
+# I will disable linting and typechecking for this file.
 
 # pylint: disable=all
+# mypy: ignore-errors
 
 from multiprocessing.pool import IMapIterator, Pool, starmapstar
 from typing import Callable

--- a/src/objects.py
+++ b/src/objects.py
@@ -101,7 +101,7 @@ class Plane(Object):
 class Polygon(Object):
 	""" The specific values necessary for Polygons. """
 
-	def __init__(self, vertices: list):
+	def __init__(self, vertices: list[np.ndarray]):
 		super().__init__()
 
 		assert len(vertices) >= 3, "Polygon must have at least 3 vertices"
@@ -215,7 +215,7 @@ class Triangle(Polygon):
  	so 3-sided Polygons will be automatically converted to Triangles.
 	"""
 
-	def __init__(self, vertices: list):
+	def __init__(self, vertices: list[np.ndarray]):
 		super().__init__(vertices)
 
 		assert len(vertices) == 3, "Triangle must have 3 vertices"

--- a/src/objects.py
+++ b/src/objects.py
@@ -50,7 +50,7 @@ class Circle(Object):
 		normal = normalized(normal)
 		self._plane = Plane(position, normal)
 
-	def normal(self, point: np.ndarray = None) -> np.ndarray:
+	def normal(self, point: np.ndarray | None = None) -> np.ndarray:
 		return self._plane.normal(point)
 
 	def ray_intersection(self, ray: Ray) -> RayCollision | None:
@@ -78,7 +78,7 @@ class Plane(Object):
 		self._normal = normalized(normal)
 		self._distance_from_origin = -1 * np.dot(normal, position)
 
-	def normal(self, point: np.ndarray = None) -> np.ndarray:
+	def normal(self, point: np.ndarray | None = None) -> np.ndarray:
 		return self._normal
 
 	def ray_intersection(self, ray: Ray) -> RayCollision | None:
@@ -119,10 +119,10 @@ class Polygon(Object):
 		self._plane_dominant_coord = np.where(np.abs(_normal) == np.max(np.abs(_normal)))[0][0]
 		self._flattened_vertices = [np.delete(v, self._plane_dominant_coord) for v in self._vertices]
 
-	def normal(self, point: np.ndarray = None) -> np.ndarray:
+	def normal(self, point: np.ndarray | None = None) -> np.ndarray:
 		return self._plane.normal(point)
 
-	def ray_intersection(self, ray: Ray) -> RayCollision|None:
+	def ray_intersection(self, ray: Ray) -> RayCollision | None:
 		# See if ray intersects with plane
 		plane_collision = self._plane.ray_intersection(ray)
 		if plane_collision is None:
@@ -183,7 +183,7 @@ class Sphere(Object):
 	def normal(self, point: np.ndarray) -> np.ndarray:
 		return normalized(point - self.position)
 
-	def ray_intersection(self, ray: Ray) -> RayCollision|None:
+	def ray_intersection(self, ray: Ray) -> RayCollision | None:
 		dist = self.position - ray.origin
 		dist_sqr = np.dot(dist, dist)
 		dist_mag = np.sqrt(dist_sqr)

--- a/src/ray.py
+++ b/src/ray.py
@@ -5,7 +5,6 @@ Classes to define the properties and behaviors of rays.
 
 import numpy as np
 
-from scene import Scene
 from vector import magnitude
 
 
@@ -26,17 +25,3 @@ class Ray:
 	def __init__(self, origin: np.ndarray, direction: np.ndarray):
 		self.origin = origin
 		self.direction = direction
-
-	def cast(self, scene: Scene) -> RayCollision | None:
-		""" Projects the ray into the scene and returns the closest object collision. """
-
-		closest_collision: RayCollision | None = None
-
-		# Find the closest object that intersects with the ray
-		for obj in scene.objects:
-			collision = obj.ray_intersection(self)
-			if collision is not None:
-				if closest_collision is None or collision.distance < closest_collision.distance:
-					closest_collision = collision
-
-		return closest_collision

--- a/src/ray.py
+++ b/src/ray.py
@@ -27,10 +27,10 @@ class Ray:
 		self.origin = origin
 		self.direction = direction
 
-	def cast(self, scene: Scene) -> RayCollision|None:
+	def cast(self, scene: Scene) -> RayCollision | None:
 		""" Projects the ray into the scene and returns the closest object collision. """
 
-		closest_collision: RayCollision = None
+		closest_collision: RayCollision | None = None
 
 		# Find the closest object that intersects with the ray
 		for obj in scene.objects:

--- a/src/ray_tracer.py
+++ b/src/ray_tracer.py
@@ -74,7 +74,7 @@ def _get_color(origin: np.ndarray, direction: np.ndarray, scene: Scene,
 
 	# Initialize and cast the ray
 	ray = Ray(origin, direction)
-	collision = ray.cast(scene)
+	collision = scene.cast_ray(ray)
 
 	# Shade the pixel using the collided object
 	if collision is not None:
@@ -107,7 +107,7 @@ def _is_in_shadow(point: np.ndarray, scene: Scene) -> bool:
 	ray = Ray(point, scene.light_direction)
 	ray.origin += ray.direction * 0.01	# Offset to avoid colliding with the object
 
-	collision = ray.cast(scene)
+	collision = scene.cast_ray(ray)
 	return collision is not None
 
 

--- a/src/scene.py
+++ b/src/scene.py
@@ -5,6 +5,8 @@ Classes that define the scene to be ray traced.
 
 import numpy as np
 
+from objects import Object
+from ray import Ray, RayCollision
 from vector import magnitude, normalized
 
 
@@ -29,7 +31,7 @@ class Scene:
 	""" Defines the entire scene and all objects within it. """
 
 	def __init__(self, camera: Camera, light_direction: np.ndarray, light_color: np.ndarray,
-			ambient_light_color: np.ndarray, background_color: np.ndarray, objects: list):
+			ambient_light_color: np.ndarray, background_color: np.ndarray, objects: list[Object]):
 
 		# Camera
 		self.camera = camera
@@ -42,3 +44,17 @@ class Scene:
 
 		# Objects
 		self.objects = objects
+
+	def cast_ray(self, ray: Ray) -> RayCollision | None:
+		""" Projects the ray into the scene and returns the closest object collision. """
+
+		closest_collision: RayCollision | None = None
+
+		# Find the closest object that intersects with the ray
+		for obj in self.objects:
+			collision = obj.ray_intersection(ray)
+			if collision is not None:
+				if closest_collision is None or collision.distance < closest_collision.distance:
+					closest_collision = collision
+
+		return closest_collision

--- a/src/scene_importer.py
+++ b/src/scene_importer.py
@@ -116,7 +116,7 @@ def _load_object(json_value, error_prefix="Object") -> Object:
 	elif obj_type == "triangle":
 		obj = _load_triangle(json_value, error_prefix=f"{error_prefix}<Triangle>")
 	else:
-		raise f"{error_prefix} must have valid type, not {obj_type}"
+		raise TypeError(f"{error_prefix} must have valid type, not {obj_type}")
 
 	# Load in universal object values
 	name = json_value.get("name")

--- a/src/scene_importer.py
+++ b/src/scene_importer.py
@@ -76,7 +76,9 @@ def _load_from_json(json: dict) -> Scene:
 	return scene
 
 
-def _load_objects(json_value, default: list = None, error_prefix="Objects") -> list:
+def _load_objects(json_value,
+			default: list[Object] | None = None,
+			error_prefix="Objects") -> list[Object]:
 	""" Takes a list of dictionaries and imports each of them as an Object. """
 
 	objects = []
@@ -92,7 +94,7 @@ def _load_objects(json_value, default: list = None, error_prefix="Objects") -> l
 def _load_object(json_value, error_prefix="Object") -> Object:
 	""" Imports a dictionary as an Object. """
 
-	obj = None
+	obj: Object | None = None
 
 	assert json_value is not None, f"{error_prefix} must not be missing"
 	assert isinstance(json_value, dict), f"{error_prefix} must be type dict, not {type(json_value)}"
@@ -210,7 +212,7 @@ def _load_triangle(json_value, error_prefix="Triangle") -> Triangle:
 
 
 def _validate_position_vector(json_value,
-				default: list = None,
+				default: list[float] | None = None,
 				error_prefix="Position") -> np.ndarray:
 	""" Imports a list as a position vector. """
 
@@ -222,7 +224,7 @@ def _validate_position_vector(json_value,
 
 
 def _validate_direction_vector(json_value,
-				default: list = None,
+				default: list[float] | None = None,
 				error_prefix="Direction") -> np.ndarray:
 	""" Imports a list as a direction vector, verifying it is normalized. """
 
@@ -244,7 +246,7 @@ def _validate_direction_vector(json_value,
 
 
 def _validate_color_vector(json_value,
-				default: list = None,
+				default: list[float] | None = None,
 				error_prefix="Color") -> np.ndarray:
 	""" Imports a list as a color vector, verifying the proper range of values. """
 
@@ -256,8 +258,8 @@ def _validate_color_vector(json_value,
 
 
 def _validate_list(json_value,
-			length: int = None,
-			default: list = None,
+			length: int | None = None,
+			default: list | None = None,
 			error_prefix = "List") -> list:
 	""" Imports a list. """
 
@@ -275,10 +277,10 @@ def _validate_list(json_value,
 
 
 def _validate_number(json_value,
-			_min: float|int = None,
-			_max: float|int = None,
-			default: float|int = None,
-			error_prefix = "Number") -> float|int:
+			_min: float | int | None = None,
+			_max: float | int | None = None,
+			default: float | int | None = None,
+			error_prefix = "Number") -> float | int:
 	""" Imports a number. """
 
 	if json_value is None and default is not None:

--- a/src/writers.py
+++ b/src/writers.py
@@ -39,12 +39,13 @@ def write_to_png(screen: np.ndarray, output_file_path: str, progress_bar: bool):
 	width = len(screen)
 	height = len(screen[0])
 
-	screen = (screen * 255).astype(int)
+	screen = screen * 255
 	coords: Iterable = [(x,y) for y in range(height) for x in range(width)]
 	if progress_bar:
 		coords = tqdm(coords)
 
 	image = Image.new('RGB', (width, height))
 	for xy in coords:
-		image.putpixel(xy, tuple(screen[xy]))
+		r, g, b = screen[xy]
+		image.putpixel(xy, (r, g, b))
 	image.save(output_file_path)

--- a/src/writers.py
+++ b/src/writers.py
@@ -39,7 +39,7 @@ def write_to_png(screen: np.ndarray, output_file_path: str, progress_bar: bool):
 	width = len(screen)
 	height = len(screen[0])
 
-	screen = screen * 255
+	screen = (screen * 255).astype(int)
 	coords: Iterable = [(x,y) for y in range(height) for x in range(width)]
 	if progress_bar:
 		coords = tqdm(coords)


### PR DESCRIPTION
### Added

- `mypy` dependencies to `requirements.txt`
- `mypy` extensions for `vscode`
- Typechecking step to `validate` workflow
- `mypy` cache to gitignore
- Instructions on `mypy` to the README

### Changed

- `istarmap` file to disable type-checking as well as linting
- Ray-casting logic to be located in the Scene object to flatten a circular dependency
- Type-checked all files
  - Added explicit generic types to all lists
  - Added explicit `None` types to all optional parameters

### Fixed

- Exception being raised as string instead of `Exception` class
- PNG writer not being type-safe and throwing errors