### PR TITLE
Use numpy typing module

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -13,7 +13,7 @@ from PIL import Image
 COLOR_MODE = 'RGB'
 
 
-def random_str(length):
+def random_str(length: int) -> str:
 	"Generates a random string of the given length."
 
 	return ''.join(choice(ascii_letters) for _ in range(length))

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -7,6 +7,7 @@ import sys
 from string import ascii_letters
 
 import numpy as np
+from numpy.typing import NDArray
 from PIL import Image
 
 
@@ -32,7 +33,7 @@ def assert_supported_extension(output_file_path: str) -> None:
 		sys.exit(1)
 
 
-def export(screen: np.ndarray, output_file_path: str) -> None:
+def export(screen: NDArray[np.float_], output_file_path: str) -> None:
 	"Writes the screen to a file using the encoding of the file extension."
 
 	height, width, depth = screen.shape

--- a/src/lib/_itertools.py
+++ b/src/lib/_itertools.py
@@ -4,7 +4,7 @@
 import itertools
 
 
-def closed_pairwise(iterable):
+def closed_pairwise(iterable: list) -> itertools.pairwise:
 	"""
 	Similar to `itertools.pairwise`, but loops around to pair the first and last elements too.
 	s -> (s0, s1), (s1, s2), (s2, s3), ..., (sn-1, sn), (sn, s0)

--- a/src/objects.py
+++ b/src/objects.py
@@ -2,6 +2,7 @@
 
 
 import numpy as np
+from numpy.typing import NDArray
 
 from lib._itertools import closed_pairwise
 from ray import Ray, RayCollision
@@ -15,12 +16,12 @@ class Object:
 	ambient_coefficient: float = 0
 	diffuse_coefficient: float = 0
 	specular_coefficient: float = 0
-	diffuse_color: np.ndarray = np.array([0, 0, 0])
-	specular_color: np.ndarray = np.array([0, 0, 0])
+	diffuse_color: NDArray[np.float_] = np.array([0, 0, 0])
+	specular_color: NDArray[np.float_] = np.array([0, 0, 0])
 	gloss_coefficient: float = 0
 	reflectivity: float = 0
 
-	def normal(self, point: np.ndarray) -> np.ndarray:
+	def normal(self, point: NDArray[np.float_]) -> NDArray[np.float_]:
 		"""
 		The "up" direction from this point on the object.
 		Assumes the point is actually on the object.
@@ -37,16 +38,16 @@ class Object:
 class Plane(Object):
 	"The specific values necessary for Planes."
 
-	_normal: np.ndarray
+	_normal: NDArray[np.float_]
 	_distance_from_origin: float
 
-	def __init__(self, position: np.ndarray, normal: np.ndarray):
+	def __init__(self, position: NDArray[np.float_], normal: NDArray[np.float_]):
 		super().__init__()
 
 		self._normal = normalized(normal)
 		self._distance_from_origin = -1 * np.dot(normal, position)
 
-	def normal(self, point: np.ndarray | None = None) -> np.ndarray:
+	def normal(self, point: NDArray[np.float_] | None = None) -> NDArray[np.float_]:
 		return self._normal
 
 	def ray_intersection(self, ray: Ray) -> RayCollision | None:
@@ -69,11 +70,11 @@ class Plane(Object):
 class Circle(Object):
 	"The specific values necessary for Circles."
 
-	position: np.ndarray
+	position: NDArray[np.float_]
 	radius: float
 	_plane: Plane
 
-	def __init__(self, position: np.ndarray, normal: np.ndarray, radius: float):
+	def __init__(self, position: NDArray[np.float_], normal: NDArray[np.float_], radius: float):
 		super().__init__()
 
 		self.position = position
@@ -82,7 +83,7 @@ class Circle(Object):
 		normal = normalized(normal)
 		self._plane = Plane(position, normal)
 
-	def normal(self, point: np.ndarray | None = None) -> np.ndarray:
+	def normal(self, point: NDArray[np.float_] | None = None) -> NDArray[np.float_]:
 		return self._plane.normal(point)
 
 	def ray_intersection(self, ray: Ray) -> RayCollision | None:
@@ -107,12 +108,12 @@ class Polygon(Object):
 	X_AXIS_SHIFT = 0.01
 	"To make sure no flattened relative vertices lie on the x-axis."
 
-	_vertices: list[np.ndarray]
+	_vertices: list[NDArray[np.float_]]
 	_plane: Plane
 	_plane_dominant_coord: int
-	_flattened_vertices: list[np.ndarray]
+	_flattened_vertices: list[NDArray[np.float_]]
 
-	def __init__(self, vertices: list[np.ndarray]):
+	def __init__(self, vertices: list[NDArray[np.float_]]):
 		super().__init__()
 
 		assert len(vertices) >= 3, "Polygon must have at least 3 vertices"
@@ -128,10 +129,10 @@ class Polygon(Object):
 
 		# Project all the vertices onto a 2D plane (for future intersection calculations)
 		self._plane_dominant_coord: int = np.where(np.abs(_normal) == np.max(np.abs(_normal)))[0][0]
-		self._flattened_vertices: list[np.ndarray] = [np.delete(v, self._plane_dominant_coord)
+		self._flattened_vertices = [np.delete(v, self._plane_dominant_coord)
 								for v in self._vertices]
 
-	def normal(self, point: np.ndarray | None = None) -> np.ndarray:
+	def normal(self, point: NDArray[np.float_] | None = None) -> NDArray[np.float_]:
 		return self._plane.normal(point)
 
 	def ray_intersection(self, ray: Ray) -> RayCollision | None:
@@ -187,15 +188,15 @@ class Polygon(Object):
 class Sphere(Object):
 	"The specific values necessary for Spheres."
 
-	position: np.ndarray
+	position: NDArray[np.float_]
 	radius: float
 
-	def __init__(self, position: np.ndarray, radius: float):
+	def __init__(self, position: NDArray[np.float_], radius: float):
 		super().__init__()
 		self.position = position
 		self.radius = radius
 
-	def normal(self, point: np.ndarray) -> np.ndarray:
+	def normal(self, point: NDArray[np.float_]) -> NDArray[np.float_]:
 		return normalized(point - self.position)
 
 	def ray_intersection(self, ray: Ray) -> RayCollision | None:
@@ -235,7 +236,7 @@ class Triangle(Polygon):
 
 	_flattened_area: float
 
-	def __init__(self, vertices: list[np.ndarray]):
+	def __init__(self, vertices: list[NDArray[np.float_]]):
 		super().__init__(vertices)
 
 		assert len(vertices) == 3, "Triangle must have 3 vertices"
@@ -267,7 +268,7 @@ class Triangle(Polygon):
 		return RayCollision(self, ray, intersection)
 
 	@staticmethod
-	def area(vertices: list[np.ndarray]) -> float:
+	def area(vertices: list[NDArray[np.float_]]) -> float:
 		"Given the three vertices, returns the area of the enclosed triangle."
 
 		assert len(vertices) == 3, "Must have 3 vertices to be a triangle"

--- a/src/ray.py
+++ b/src/ray.py
@@ -2,6 +2,7 @@
 
 
 import numpy as np
+from numpy.typing import NDArray
 
 from vector import magnitude
 
@@ -9,10 +10,10 @@ from vector import magnitude
 class Ray:
 	"Represents a semi-infinite line."
 
-	origin: np.ndarray
-	direction: np.ndarray
+	origin: NDArray[np.float_]
+	direction: NDArray[np.float_]
 
-	def __init__(self, origin: np.ndarray, direction: np.ndarray):
+	def __init__(self, origin: NDArray[np.float_], direction: NDArray[np.float_]):
 		self.origin = origin
 		self.direction = direction
 
@@ -22,10 +23,10 @@ class RayCollision:
 
 	# obj: Object # would cause a circular import
 	ray: Ray
-	position: np.ndarray
+	position: NDArray[np.float_]
 	distance: float
 
-	def __init__(self, obj, ray: Ray, position: np.ndarray):
+	def __init__(self, obj, ray: Ray, position: NDArray[np.float_]):
 		self.obj = obj
 		self.ray = ray
 		self.position = position

--- a/src/ray_tracer.py
+++ b/src/ray_tracer.py
@@ -100,8 +100,6 @@ def _get_color(scene: Scene, reflection_limit: int,
 
 		# Reflections (recursive)
 		sight_reflection_direction = ray.direction - 2 * normal * np.dot(ray.direction, normal)
-		# Avoid colliding with the same surface
-		offset_origin = collision.position + 0.01*sight_reflection_direction
 		reflected_color = _get_color(scene, reflection_limit, collision.position,
 						sight_reflection_direction, fade*collision.obj.reflectivity, reflections+1)
 
@@ -117,9 +115,6 @@ def _is_in_shadow(scene: Scene, point: NDArray[np.float_]) -> bool:
 	"Casts a ray toward the light source to determine if the point is in shadow."
 
 	ray = Ray(point, scene.light_direction)
-	# Offset to avoid colliding with the object
-	ray.origin += COLLISION_NORMAL_OFFSET * ray.direction
-
 	collision = scene.cast_ray(ray)
 	return collision is not None
 

--- a/src/ray_tracer.py
+++ b/src/ray_tracer.py
@@ -83,7 +83,7 @@ def _ray_trace_pixel(tuple_input: tuple[int, int, Scene, np.ndarray, np.ndarray,
 
 
 def _get_color(origin: np.ndarray, direction: np.ndarray, scene: Scene,
-		fade=1, reflections=0, reflection_limit=float("inf")):
+		fade=1, reflections=0, reflection_limit=float("inf")) -> np.ndarray:
 	"Recursively casts rays to retrieve the color for the original ray collision."
 
 	if fade <= FADE_LIMIT or reflections > reflection_limit:

--- a/src/ray_tracer.py
+++ b/src/ray_tracer.py
@@ -9,6 +9,7 @@ from multiprocessing import cpu_count, Pool
 from typing import Iterable
 
 import numpy as np
+from numpy.typing import NDArray
 from tqdm import tqdm
 
 from ray import Ray
@@ -25,18 +26,18 @@ COLLISION_NORMAL_OFFSET = 0.01
 
 
 def ray_trace(scene: Scene, width: int, height: int,
-		reflection_limit: int, progress_bar: bool) -> np.ndarray:
+		reflection_limit: int, progress_bar: bool) -> NDArray[np.float_]:
 	"Ray traces the given scene and returns a numpy array of pixel colors."
 
 	# Save time by pre-calcuating constant values
 	viewport_size = np.array([width, height])
-	window_size = _calculate_window_size(viewport_size,
-						scene.camera.focal_length, scene.camera.field_of_view)
+	window_size = _get_window_size(viewport_size,
+					scene.camera.focal_length, scene.camera.field_of_view)
 	window_to_viewport_size_ratio = window_size/viewport_size
 	half_window_size = window_size/2
 
 	# Set up multiprocessing pool and inputs
-	tuple_inputs = [(x, y, scene, window_to_viewport_size_ratio, half_window_size, reflection_limit)
+	tuple_inputs = [(scene, reflection_limit, x, y, window_to_viewport_size_ratio, half_window_size)
 		for y in range(height) for x in range(width)]
 	outputs = []
 
@@ -58,19 +59,13 @@ def ray_trace(scene: Scene, width: int, height: int,
 	return screen
 
 
-def _ray_trace_pixel(tuple_input: tuple[int, int, Scene, np.ndarray, np.ndarray, int]
-					 ) -> np.ndarray:
+def _ray_trace_pixel(
+		tuple_input: tuple[Scene, int, int, int, NDArray[np.float_], NDArray[np.float_]]
+	) -> NDArray[np.float_]:
 	"Retrieves the color for a given pixel."
 
 	# Unpack the input from the pool
-	x: int
-	y: int
-	scene: Scene
-	window_to_viewport_size_ratio: np.ndarray
-	half_window_size: np.ndarray
-	reflection_limit: int
-
-	x, y, scene, window_to_viewport_size_ratio, half_window_size, reflection_limit = tuple_input
+	scene, reflection_limit, x, y, window_to_viewport_size_ratio, half_window_size = tuple_input
 
 	# Find the world point of the pixel, relative to the camera's position
 	viewport_point = np.array([x, y])
@@ -78,12 +73,13 @@ def _ray_trace_pixel(tuple_input: tuple[int, int, Scene, np.ndarray, np.ndarray,
 	world_point_relative = _window_to_relative_world(window_point, scene.camera)
 
 	# Start sending out rays
-	return _get_color(scene.camera.position, normalized(world_point_relative), scene,
-			reflection_limit=reflection_limit)
+	return _get_color(scene, reflection_limit,
+			scene.camera.position, normalized(world_point_relative))
 
 
-def _get_color(origin: np.ndarray, direction: np.ndarray, scene: Scene,
-		fade=1, reflections=0, reflection_limit=float("inf")) -> np.ndarray:
+def _get_color(scene: Scene, reflection_limit: int,
+		origin: NDArray[np.float_], direction: NDArray[np.float_],
+		fade=1, reflections=0) -> NDArray[np.float_]:
 	"Recursively casts rays to retrieve the color for the original ray collision."
 
 	if fade <= FADE_LIMIT or reflections > reflection_limit:
@@ -101,16 +97,15 @@ def _get_color(origin: np.ndarray, direction: np.ndarray, scene: Scene,
 		# Avoid getting trapped inside objects
 		collision.position += COLLISION_NORMAL_OFFSET*normal
 
-		shadow = _is_in_shadow(collision.position, scene)
+		shadow = _is_in_shadow(scene, collision.position)
 
 		sight_reflection_direction = ray.direction - 2 * normal * np.dot(ray.direction, normal)
 		# Avoid colliding with the same surface
 		offset_origin = collision.position + 0.01*sight_reflection_direction
 
 		# Get the color from the reflection (recursive)
-		reflected_color = _get_color(offset_origin, sight_reflection_direction, scene,
-						fade=fade*collision.obj.reflectivity, reflections=reflections+1,
-						reflection_limit=reflection_limit)
+		reflected_color = _get_color(scene, reflection_limit, offset_origin,
+						sight_reflection_direction, fade*collision.obj.reflectivity, reflections+1)
 
 		return shade(scene, collision.obj, collision.position, view_direction, shadow, reflected_color)
 
@@ -118,7 +113,7 @@ def _get_color(origin: np.ndarray, direction: np.ndarray, scene: Scene,
 	return scene.background_color
 
 
-def _is_in_shadow(point: np.ndarray, scene: Scene) -> bool:
+def _is_in_shadow(scene: Scene, point: NDArray[np.float_]) -> bool:
 	"Casts a ray toward the light source to determine if the point is in shadow."
 
 	ray = Ray(point, scene.light_direction)
@@ -129,9 +124,8 @@ def _is_in_shadow(point: np.ndarray, scene: Scene) -> bool:
 	return collision is not None
 
 
-def _calculate_window_size(viewport_size: np.ndarray,
-				focal_length: float,
-				field_of_view: float) -> np.ndarray:
+def _get_window_size(viewport_size: NDArray[np.int_], focal_length: float, field_of_view: float
+	) -> NDArray[np.float_]:
 	"Returns the window size, given the camera properties."
 
 	x = focal_length * tan(np.deg2rad(field_of_view/2)) * 2
@@ -139,9 +133,9 @@ def _calculate_window_size(viewport_size: np.ndarray,
 	return np.array([x, y])
 
 
-def _viewport_to_window(viewport_point: np.ndarray,
-			window_to_viewport_size_ratio: np.ndarray,
-			half_window_size: np.ndarray) -> np.ndarray:
+def _viewport_to_window(viewport_point: NDArray[np.float_],
+			window_to_viewport_size_ratio: NDArray[np.float_],
+			half_window_size: NDArray[np.float_]) -> NDArray[np.float_]:
 	"Converts a point on the viewport to a point on the window."
 
 	window_point = viewport_point * window_to_viewport_size_ratio - half_window_size
@@ -149,7 +143,8 @@ def _viewport_to_window(viewport_point: np.ndarray,
 	return np.array([window_point[0], window_point[1]*-1, 0])
 
 
-def _window_to_relative_world(window_point: np.ndarray, camera: Camera) -> np.ndarray:
+def _window_to_relative_world(window_point: NDArray[np.float_], camera: Camera
+	) -> NDArray[np.float_]:
 	"Converts a point on the window to world point (relative to the camera)."
 
 	return camera.relative_look_at \

--- a/src/scene.py
+++ b/src/scene.py
@@ -2,6 +2,7 @@
 
 
 import numpy as np
+from numpy.typing import NDArray
 
 from objects import Object
 from ray import Ray, RayCollision
@@ -11,16 +12,16 @@ from vector import magnitude, normalized
 class Camera:
 	"Defines the camera position, orientation, and other settings."
 
-	position: np.ndarray
+	position: NDArray[np.float_]
 	field_of_view: float
-	relative_look_at: np.ndarray
+	relative_look_at: NDArray[np.float_]
 	focal_length: float
-	forward: np.ndarray
-	up: np.ndarray
-	right: np.ndarray
+	forward: NDArray[np.float_]
+	up: NDArray[np.float_]
+	right: NDArray[np.float_]
 
-	def __init__(self, camera_look_at: np.ndarray, camera_look_from: np.ndarray,
-			camera_look_up: np.ndarray, field_of_view: float):
+	def __init__(self, camera_look_at: NDArray[np.float_], camera_look_from: NDArray[np.float_],
+			camera_look_up: NDArray[np.float_], field_of_view: float):
 
 		self.position = camera_look_from
 		self.field_of_view = field_of_view
@@ -37,14 +38,15 @@ class Scene:
 	"Defines the entire scene and all objects within it."
 
 	camera: Camera
-	light_direction: np.ndarray
-	light_color: np.ndarray
-	ambient_light_color: np.ndarray
-	background_color: np.ndarray
+	light_direction: NDArray[np.float_]
+	light_color: NDArray[np.float_]
+	ambient_light_color: NDArray[np.float_]
+	background_color: NDArray[np.float_]
 	objects: list[Object]
 
-	def __init__(self, camera: Camera, light_direction: np.ndarray, light_color: np.ndarray,
-			ambient_light_color: np.ndarray, background_color: np.ndarray, objects: list[Object]):
+	def __init__(self, camera: Camera, light_direction: NDArray[np.float_],
+			light_color: NDArray[np.float_], ambient_light_color: NDArray[np.float_],
+			background_color: NDArray[np.float_], objects: list[Object]):
 
 		# Camera
 		self.camera = camera

--- a/src/scene_importer.py
+++ b/src/scene_importer.py
@@ -5,6 +5,7 @@ from json import loads as json_as_dict
 import sys
 
 import numpy as np
+from numpy.typing import NDArray
 
 from objects import Circle, Object, Plane, Polygon, Sphere, Triangle
 from scene import Camera, Scene
@@ -211,7 +212,7 @@ def _load_triangle(json_value, error_prefix="Triangle") -> Triangle:
 
 def _validate_position_vector(json_value,
 				default: list[float] | None = None,
-				error_prefix="Position") -> np.ndarray:
+				error_prefix="Position") -> NDArray[np.float_]:
 	"Imports a list as a position vector."
 
 	json_value = _validate_list(json_value, length=3, default=default, error_prefix=error_prefix)
@@ -223,7 +224,7 @@ def _validate_position_vector(json_value,
 
 def _validate_direction_vector(json_value,
 				default: list[float] | None = None,
-				error_prefix="Direction") -> np.ndarray:
+				error_prefix="Direction") -> NDArray[np.float_]:
 	"Imports a list as a direction vector, verifying it is normalized."
 
 	json_value = _validate_list(json_value, length=3, default=default, error_prefix=error_prefix)
@@ -245,7 +246,7 @@ def _validate_direction_vector(json_value,
 
 def _validate_color_vector(json_value,
 				default: list[float] | None = None,
-				error_prefix="Color") -> np.ndarray:
+				error_prefix="Color") -> NDArray[np.float_]:
 	"Imports a list as a color vector, verifying the proper range of values."
 
 	json_value = _validate_list(json_value, length=3, default=default, error_prefix=error_prefix)

--- a/src/shader.py
+++ b/src/shader.py
@@ -2,13 +2,15 @@
 
 
 import numpy as np
+from numpy.typing import NDArray
 
 from objects import Object
 from scene import Scene
 
 
-def shade(scene: Scene, obj: Object, position: np.ndarray, view_direction: np.ndarray,
-		shadow: bool, reflected_color: np.ndarray) -> np.ndarray:
+def shade(scene: Scene, obj: Object, position: NDArray[np.float_],
+		view_direction: NDArray[np.float_], shadow: bool, reflected_color: NDArray[np.float_]
+	) -> NDArray[np.float_]:
 	"""
 	Applies [Phong shading](https://en.wikipedia.org/wiki/Phong_shading)
 	to the given object and returns the color.

--- a/src/vector.py
+++ b/src/vector.py
@@ -2,16 +2,17 @@
 
 
 import numpy as np
+from numpy.typing import NDArray
 
 
-def magnitude(vector: np.ndarray) -> float:
+def magnitude(vector: NDArray) -> float:
 	"Returns the scalar length of the vector."
 
 	assert vector.ndim == 1, "A vector must be 1-dimensional"
 	return float(np.linalg.norm(vector))
 
 
-def normalized(vector: np.ndarray) -> np.ndarray:
+def normalized(vector: NDArray) -> NDArray[np.float_]:
 	"Returns a new vector pointing in the same direction but with a length of 1 (or 0)."
 
 	mag = magnitude(vector)


### PR DESCRIPTION
### Added

- Missing types
- `numpy` array dtypes (`float`, `int`, etc)

### Changed

- `numpy` types to use official `numpy.typing` module (specifically `NDArray[dtype]`)
- Calculations to use more `numpy` vectorized methods when possible
- Reordered some method parameters

### Removed

- Redundant `position` offsets when checking shadows/reflections (could've potentially been a bug)