### PR TITLE
Fix errors from `ruff` and `mypy`

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,5 +27,5 @@ jobs:
       - name: Lint
         run: ruff check
 
-      - name: Typecheck
+      - name: Type check
         run: mypy .

--- a/ruff.toml
+++ b/ruff.toml
@@ -4,7 +4,6 @@ target-version = "py312"
 [lint]
 select = ["ALL"]
 ignore = [
-	"ANN101",	# Will likely be removed in future update - https://docs.astral.sh/ruff/rules/missing-type-self/
 	"D203",		# Conflicts with D211 - https://docs.astral.sh/ruff/rules/one-blank-line-before-class/
 	"D206",		# Using tabs - https://docs.astral.sh/ruff/rules/indent-with-spaces/
 	"D212",		# Conflicts with D213 - https://docs.astral.sh/ruff/rules/multi-line-summary-first-line/

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 from os import getenv
 
 from dotenv import load_dotenv
+
 from exporter import assert_supported_extension, export
 from importer import import_scene
 from ray_tracer import ray_trace

--- a/src/importer.py
+++ b/src/importer.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
+
 from objects import Circle, Object, Plane, Polygon, Sphere, Triangle
 from scene import Camera, Scene
 from vector import magnitude, normalized

--- a/src/objects.py
+++ b/src/objects.py
@@ -2,8 +2,9 @@
 
 
 import numpy as np
-from lib._itertools import closed_pairwise
 from numpy.typing import NDArray
+
+from lib._itertools import closed_pairwise
 from ray import Ray, RayCollision
 from vector import magnitude, normalized
 

--- a/src/ray.py
+++ b/src/ray.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 from numpy.typing import NDArray
+
 from vector import magnitude
 
 

--- a/src/ray_tracer.py
+++ b/src/ray_tracer.py
@@ -7,10 +7,11 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from numpy.typing import NDArray
+from tqdm import tqdm
+
 from ray import Ray
 from scene import Camera, Scene
 from shader import shade
-from tqdm import tqdm
 from vector import normalized
 
 if TYPE_CHECKING:

--- a/src/scene.py
+++ b/src/scene.py
@@ -16,9 +16,9 @@ class Camera:
 	field_of_view: float
 	relative_look_at: NDArray[np.float64]
 	focal_length: float
-	forward: NDArray[np.float64]
-	up: NDArray[np.float64]
-	right: NDArray[np.float64]
+	forward: NDArray[np.floating]
+	up: NDArray[np.floating]
+	right: NDArray[np.floating]
 
 	def __init__(
 		self,

--- a/src/scene.py
+++ b/src/scene.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 from numpy.typing import NDArray
+
 from objects import Object
 from ray import Ray, RayCollision
 from vector import magnitude, normalized

--- a/src/shader.py
+++ b/src/shader.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 from numpy.typing import NDArray
+
 from objects import Object
 from scene import Scene
 


### PR DESCRIPTION
It's been a while since a PR has been created for this repository. In the meantime, `ruff` and `mypy` have been updated and throw new errors.

See https://github.com/JstnMcBrd/ray-tracer/actions/runs/14995256712/job/42127836798?pr=25

-----

### Fixed

- Import order lint errors

### Removed

- Deprecated rule from ignore list that has since been removed